### PR TITLE
add error getter and thrower

### DIFF
--- a/lib/core/core.c
+++ b/lib/core/core.c
@@ -93,6 +93,33 @@ __job_notify_with_job(__job_get_job_by_name(CORE_JOB_NAME),
 }
 
 
+jes_err_t __core_error_get(char* job_name){
+    job_struct_t* pj = __job_get_job_by_name(job_name);
+    if (pj == NULL) { return e_err_unknown_job; }
+    return pj->error;
+}
+
+
+jes_err_t __core_error_get_any(){
+    job_struct_t** job_list = __core_get_job_list();
+    job_struct_t* cur = *job_list;
+    jes_err_t e;
+    while(cur != NULL){
+        e = cur->error;
+        if(e != e_err_no_err) { return e; }
+        cur = cur->pn;
+    }
+    return e_err_no_err;
+}
+
+
+void __core_error_throw(jes_err_t e, job_struct_t* pj){
+    if (pj == NULL) { return; }
+    pj->error = e;
+}
+
+
+
 void __core_job(void* p){
     while(1){
         job_struct_t* pj = __job_sleep_until_notified_with_job();

--- a/lib/core/core.h
+++ b/lib/core/core.h
@@ -61,6 +61,23 @@ void __core_notify(job_struct_t* pjob_to_run,
                     uint8_t from_isr);
 
 
+/// @brief Get the error of a job.
+/// @param job_name: job name (callable by CLI).
+/// @return Error of the given job as stored by the core.
+jes_err_t __core_error_get(char* job_name);
+
+
+/// @brief Get the first error that of all jobs.
+/// @return Error of first job that has one.
+/// @note Returns `e_err_no_err` in case that every
+///       job is error-free.
+jes_err_t __core_error_get_any();
+
+
+/// @brief Actively throw an error and store it in the core.
+/// @param e Error to throw.
+void __core_error_throw(jes_err_t e, job_struct_t* pj);
+
 /// @brief Main core job. Handles calls and runs jobs.
 /// @param p: Mandatory args pointer.
 void __core_job(void* p);

--- a/lib/jescore_api/jescore_api.c
+++ b/lib/jescore_api/jescore_api.c
@@ -101,6 +101,23 @@ void* jes_job_get_param(void){
 }
 
 
+jes_err_t jes_error_get(char* job_name){
+    return __core_error_get(job_name);
+}
+
+
+jes_err_t jes_error_get_any(void){
+    return __core_error_get_any();
+}
+
+
+void jes_throw_error(jes_err_t e){
+    TaskHandle_t hj = xTaskGetCurrentTaskHandle();
+    job_struct_t* pj = __job_get_job_by_handle(hj);
+    return __core_error_throw(e, pj);
+}
+
+
 void jes_notify_job(const char* name, void* notification){
     __job_notify_generic(__job_get_job_by_name(name), notification, 0);
 }

--- a/lib/jescore_api/jescore_api.h
+++ b/lib/jescore_api/jescore_api.h
@@ -99,6 +99,26 @@ jes_err_t jes_job_set_param(void* p);
 void* jes_job_get_param(void);
 
 
+/// @brief Get the field `error` of a given job.
+/// @param job_name Name of the job.
+/// @return Stored error.
+jes_err_t jes_error_get(char* job_name);
+
+
+/// @brief Get the first error that of all jobs.
+/// @return Error of first job that has one.
+/// @note Returns `e_err_no_err` in case that every
+///       job is error-free.
+/// @note Use this function to quickly spot if the
+///       program is error free.
+jes_err_t jes_error_get_any(void);
+
+
+/// @brief 
+/// @param e 
+void jes_throw_error(jes_err_t e);
+
+
 /// @brief Notify a job with an optional message.
 /// @param name Name of job which should be notified.
 /// @param notification Optional pointer to notification value.

--- a/test/common_test.c
+++ b/test/common_test.c
@@ -47,7 +47,8 @@ void test_all(void* p) {
     RUN_TEST(test_set_get_args);
     RUN_TEST(test_set_job_get_params);
     RUN_TEST(test_launch_job_args);
-    // RUN_TEST(test_core_job_launch_prohibited);
+    RUN_TEST(test_error_throw_get);
+    RUN_TEST(test_core_job_launch_prohibited);
     RUN_TEST(test_notify_job_and_wait);
     
     UNITY_END();

--- a/test/common_test.h
+++ b/test/common_test.h
@@ -26,6 +26,7 @@ void test_launch_job(void);
 void test_set_get_args(void);
 void test_set_job_get_params(void);
 void test_launch_job_args(void);
+void test_error_throw_get(void);
 void test_core_job_launch_prohibited(void);
 void test_notify_job_and_wait(void);
 

--- a/test/test_api_functions.c
+++ b/test/test_api_functions.c
@@ -220,13 +220,30 @@ void test_launch_job_args(void){
     TEST_ASSERT_EQUAL_STRING(DUMMY_ARGS_MODIF, args);
 }
 
+void test_error_throw_get(void){
+    jes_err_t e;
+    e = jes_error_get(DUMMY_JOB_LOOP_NAME);
+    TEST_ASSERT_EQUAL(e_err_no_err, e);
+    e = jes_error_get_any();
+    TEST_ASSERT_EQUAL(e_err_no_err, e);
+    __core_error_throw(e_err_driver_fail, __job_get_job_by_name(DUMMY_JOB_LOOP_NAME));
+    e = jes_error_get(DUMMY_JOB_LOOP_NAME);
+    TEST_ASSERT_EQUAL(e_err_driver_fail, e);
+}
+
 void test_core_job_launch_prohibited(void){
     jes_err_t stat = jes_launch_job(CORE_JOB_NAME);
-    TEST_ASSERT_EQUAL_INT(e_err_prohibited, stat);
+    TEST_ASSERT_EQUAL_INT(e_err_no_err, stat);
+    jes_delay_job_ms(10);
+    TEST_ASSERT_EQUAL(e_err_prohibited, jes_error_get(CORE_JOB_NAME));
     stat = jes_launch_job(ERROR_HANDLER_NAME);
-    TEST_ASSERT_EQUAL_INT(e_err_prohibited, stat);
+    TEST_ASSERT_EQUAL_INT(e_err_no_err, stat);
+    jes_delay_job_ms(10);
+    TEST_ASSERT_EQUAL(e_err_prohibited, jes_error_get(ERROR_HANDLER_NAME));
     stat = jes_launch_job(CLI_SERVER_NAME);
-    TEST_ASSERT_EQUAL_INT(e_err_prohibited, stat);
+    TEST_ASSERT_EQUAL_INT(e_err_no_err, stat);
+    jes_delay_job_ms(10);
+    TEST_ASSERT_EQUAL(e_err_prohibited, jes_error_get(CLI_SERVER_NAME));
 }
 
 


### PR DESCRIPTION
New API functions:
- `jes_error_get()`: get error of a job
- `jes_error_get_any()`: get first error of job list (useful for system health checks)
- `jes_throw_error()`: throw an error under a custom condition from within a job

