### PR TITLE
v2.2.1

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -13,8 +13,7 @@ jobs:
                   examples/example_sync_async.cpp,
                   examples/example_blink_stm32g431.c,
                   examples/example_blink_stm32h753.c,
-                  examples/example_blink_stm32l476.c,
-                  examples/example_blink_stm32.c]
+                  examples/example_blink_stm32l476.c]
 
     steps:
       - uses: actions/checkout@v3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 2.2.1 - 2025-09-2x
+## 2.2.1 - 2025-09-29
 
 ### Added
 - 💬 UART queue commands for invalid data and CLI session closing

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@
 
 ### Fixed
 - 🔆 Core initializer now calls all registrations in one place 
-- `jescore dynamic linker` adds the FW version to ESP32 builds again
+- 🔢 `jescore dynamic linker` adds the FW version to ESP32 builds again
 
 ### Removed
 - 🛠️ Public reference to CLI helper functions

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,27 @@
 # Changelog
 
+## 2.2.1 - 2025-09-2x
+
+### Added
+- 💬 UART queue commands for invalid data and CLI session closing
+- 🌊 Early termination on CLI input overflow 
+- 🔆 Core now checks for errors in job **before** launch as well
+- 🛡️ Macros for generic resource protection
+- ‼️ UART double buffer to stop DMA override of burst data
+
+### Changed
+- 🚫 Shorter error messages
+- 🧑‍🌾 Reduced heap size for STM32 projects
+
+### Fixed
+- 🔆 Core initializer now calls all registrations in one place 
+- `jescore dynamic linker` adds the FW version to ESP32 builds again
+
+### Removed
+- 🛠️ Public reference to CLI helper functions
+- ❌ `errorhandler` is now inline and no longer a job
+- 😺 `jescore dynamic linker` will no longer log git information
+
 ## 2.2.0 - 2025-09-23
 
 ### Added

--- a/examples/example_blink_stm32.c
+++ b/examples/example_blink_stm32.c
@@ -1,3 +1,0 @@
-int main(void){
-    
-}

--- a/include/board_parser.h
+++ b/include/board_parser.h
@@ -254,7 +254,7 @@
 #ifdef BUILD_FOR_STM32
 #include "FreeRTOS.h"
 
-#define BOARD_MIN_JOB_HEAP_MEM 512
+#define BOARD_MIN_JOB_HEAP_MEM 256
 #ifndef BUILD_PLATFORM_NAME
 #define BUILD_PLATFORM_NAME "STM32"
 #endif

--- a/jescore_cli/tests/test_cli.py
+++ b/jescore_cli/tests/test_cli.py
@@ -74,7 +74,7 @@ def test_cli_stats():
         assert "clisrv" in stat
         assert "stats" in stat
         assert "help" in stat
-        assert "errorhandler" in stat
+        assert "errh" in stat
         assert "core" in stat 
 
 def test_cli_logp():

--- a/jescore_cli/tests/test_cli.py
+++ b/jescore_cli/tests/test_cli.py
@@ -74,7 +74,6 @@ def test_cli_stats():
         assert "clisrv" in stat
         assert "stats" in stat
         assert "help" in stat
-        assert "errh" in stat
         assert "core" in stat 
 
 def test_cli_logp():

--- a/jescore_cli/tests/test_cli.py
+++ b/jescore_cli/tests/test_cli.py
@@ -19,6 +19,20 @@ for port in ports:
 def test_cli_init():
     assert cli.os_type == platform.system()
 
+def test_cli_unknown():
+    for port in device_ports:
+        msg = "test"
+        stat = cli.uartTransceive(msg, port=port)
+        assert stat[0] == "(E:) Job not registered! (8)"
+        assert stat[1] == CLI_PREFIX_MCU
+
+def test_cli_denied():
+    for port in device_ports:
+        msg = "core"
+        stat = cli.uartTransceive(msg, port=port)
+        assert stat[0] == "(E:) Access denied! (10)"
+        assert stat[1] == CLI_PREFIX_MCU
+
 def test_cli_echo():
     for port in device_ports:
         msg = "echo test"

--- a/lib/base_jobs/base_jobs.c
+++ b/lib/base_jobs/base_jobs.c
@@ -9,7 +9,7 @@
 
 void __base_job_echo(void* p){
     job_struct_t* pj = (job_struct_t*)p;
-    uart_unif_write((char*)pj->args);
+    uart_unif_writef("%s\n\r", (char*)pj->args);
 }
 
 

--- a/lib/cli/cli.c
+++ b/lib/cli/cli.c
@@ -5,78 +5,100 @@
 #include "base_jobs.h"
 #include "job_names.h"
 #include "uart_unif.h"
+#include "core.h"
 
 
 static QueueHandle_t queue_uart;
-static uint8_t open_sess = 0;
 static uint8_t is_init = 0;
+SemaphoreHandle_t cli_lock;
 
-
-uint8_t __cli_get_sess_state(void){
-    return open_sess;
+/// @brief Reprint the CLI header.
+/// @returns status, `e_err_no_err` if OK.
+/// @note This is neccessary to determine if a transaction has finished on the 
+///       client side.
+static jes_err_t __cli_reprint_header(void){
+    if(uart_unif_write(CLI_HEADER) != 0) return e_err_driver_fail;
+    return e_err_no_err;
 }
 
-void __cli_set_sess_state(uint8_t sess_state){
-    open_sess = sess_state;
+/// @brief Get the index of the first white space in a string.
+/// @param buf String to analyze.
+/// @param len Length of string.
+/// @return Index of white space in string. Returns -1 for the absence of a white space.
+static int16_t __get_ws_index(char* buf, uint16_t len){
+    int16_t i = 0;
+    while(i < len){
+        if(buf[i] == ' '){
+            return i;
+        }
+        i++;
+    }
+    return -1;
 }
+
 
 jes_err_t __cli_init(void){
     if(is_init) return 0;
+    cli_lock = xSemaphoreCreateMutex();
+    if(cli_lock == NULL) return e_err_mem_null;
     int32_t stat;
     stat = uart_unif_init(CLI_BAUDRATE, CLI_BUF_SIZE, CLI_BUF_SIZE, (void*)&queue_uart);
     if(stat != 0) return e_err_driver_fail;
-    uart_unif_write(CLI_BOOT_MSG);
-    jes_err_t e = __job_register_job(CLI_SERVER_NAME, BOARD_MIN_JOB_HEAP_MEM, 1, cli_server, 1, e_role_core);
-    if(e != e_err_no_err) return e;
-    e = __job_register_job(PRINT_JOB_NAME, BOARD_MIN_JOB_HEAP_MEM, 1, __base_job_echo, 0, e_role_base);
-    if(e != e_err_no_err) return e;
-    e = __job_launch_job_by_name(CLI_SERVER_NAME, e_origin_core);
-    if(e != e_err_no_err) return e;
     is_init = 1;
     return e_err_no_err;
 }
 
-void cli_server(void *pvParameters)
-{
-    char raw_str[__MAX_JOB_ARGS_LEN_BYTE] = {0};
+void __cli_close_sess(void){
+    uart_event_t ev;
+    ev.size = 1;
+    ev.type = __extraUART_CLOSE_SESS;
+    xQueueSend(queue_uart, &ev, portMAX_DELAY);
+}
+
+void cli_server(void *pvParameters){
+    char raw_str[__MAX_JOB_STR_LEN_BYTE] = {0};
     char* arg_str = NULL;
     job_struct_t* pj_to_do = NULL;
     uart_event_t event;
 
     while(1) {
         if (xQueueReceive(queue_uart, (void *)&event, (TickType_t)portMAX_DELAY)) {
-            open_sess = 1;
             switch (event.type) {
             case UART_DATA:
                 uart_unif_read(raw_str, event.size, portMAX_DELAY);
                 break;
             case UART_FIFO_OVF:
-                uart_unif_flush();
-                xQueueReset(queue_uart);
-                break;
+                // fallthrough to UART_BUFFER_FULL
             case UART_BUFFER_FULL:
                 uart_unif_flush();
-                pj_to_do = __job_get_job_by_name(ERROR_HANDLER_NAME);
-                pj_to_do->error = e_err_too_long;
-                __job_notify_with_job(__job_get_job_by_name(CORE_JOB_NAME), pj_to_do, 0);
                 xQueueReset(queue_uart);
-                break;
+                pj_to_do = __job_get_job_by_name(CLI_SERVER_NAME);
+                pj_to_do->caller = e_origin_core;
+                pj_to_do->error = e_err_too_long;
+                __core_notify(pj_to_do, 0);
+                continue;
             case UART_BREAK:
+                // NYI
                 break;
             case UART_PARITY_ERR:
+                // NYI
                 break;
             case UART_FRAME_ERR:
+                // NYI
                 break;
+            case __extraUART_CLOSE_SESS:
+                __cli_reprint_header();
+                continue;
             default:
                 break;
             }
             if(raw_str[event.size-1] == '\r'){
                 raw_str[event.size-1] = 0;
             }
-            int16_t ws_i = __get_ws_index(raw_str, __MAX_JOB_NAME_LEN_BYTE);
+            int16_t ws_i = __get_ws_index(raw_str, __MAX_JOB_STR_LEN_BYTE);
             if(ws_i == 0){
                 pj_to_do = __job_get_job_by_name(ERROR_HANDLER_NAME);
-                pj_to_do->caller = e_origin_cli;
+                pj_to_do->caller = e_origin_core;
                 pj_to_do->error = e_err_leading_whitespace;
             }
             else{
@@ -91,30 +113,13 @@ void cli_server(void *pvParameters)
                     }
                     else{
                         arg_str = &raw_str[ws_i+1];
-                        strcpy(pj_to_do->args, arg_str);
+                        pj_to_do->error = e_err_no_err;
+                        strncpy(pj_to_do->args, arg_str, __MAX_JOB_ARGS_LEN_BYTE);
                     }
                 }
             }
-            memset((void*)raw_str, 0, __MAX_JOB_NAME_LEN_BYTE);
-            __job_notify_with_job(__job_get_job_by_name(CORE_JOB_NAME), pj_to_do, 0);
+            memset((void*)raw_str, 0, __MAX_JOB_STR_LEN_BYTE);
+            __core_notify(pj_to_do, 0);
         }
     }
-}
-
-
-jes_err_t __cli_reprint_header(void){
-    if(uart_unif_write(CLI_HEADER) != 0) return e_err_driver_fail;
-    return e_err_no_err;
-}
-
-
-int16_t __get_ws_index(char* buf, uint16_t len){
-    int16_t i = 0;
-    while(i < len){
-        if(buf[i] == ' '){
-            return i;
-        }
-        i++;
-    }
-    return -1;
 }

--- a/lib/cli/cli.h
+++ b/lib/cli/cli.h
@@ -8,11 +8,8 @@ extern "C" {
 #include <inttypes.h>
 
 #define CLI_BUF_SIZE    256
-#define CLI_BAUDRATE        115200
+#define CLI_BAUDRATE    115200
 
-#ifndef CLI_BOOT_MSG
-#define CLI_BOOT_MSG        "\n************\n\rjescore CLI\n\r************\n\r"
-#endif
 #ifndef CLI_HEADER
 #define CLI_HEADER      "\rjescore $ "
 #endif
@@ -26,34 +23,19 @@ extern "C" {
 #define CLR_Gr  (uint8_t*)"\x1b[90m"
 #define CLR_X   (uint8_t*)"\x1b[0m"
 
-/// @brief Get the session state of the CLI (open or closed).
-/// @return Open (1) or closed (0).
-uint8_t __cli_get_sess_state(void);
-
-/// @brief Get the session state of the CLI (open or closed).
-/// @param sess_state State to be set: open (1) or closed (0).
-void __cli_set_sess_state(uint8_t sess_state);
-
-/// @brief CLI initializer.
+/// @brief CLI initializer. Only accesses hardware, buffers and variables,
+///        no jobs.
 /// @return status, `e_err_no_err` if OK.
 jes_err_t __cli_init(void);
+
+/// @brief Send a __extraUART_CLOSE_SESS command to the CLI server
+///        to terminate an open CLI session.
+void __cli_close_sess(void);
 
 /// @brief CLI serving job.
 /// @param p Mandatory args pointer.
 /// @note This job is started by the core if JES_DISABLE_CLI is not defined.
 void cli_server(void* p);
-
-/// @brief Reprint the CLI header.
-/// @returns status, `e_err_no_err` if OK.
-/// @note This is neccessary to determine if a transaction has finished on the 
-///       client side.
-jes_err_t __cli_reprint_header(void);
-
-/// @brief Get the index of the first white space in a string.
-/// @param buf String to analyze.
-/// @param len Length of string.
-/// @return Index of white space in string. Returns -1 for the absence of a white space.
-int16_t __get_ws_index(char* buf, uint16_t len);
 
 #endif
 

--- a/lib/core/core.c
+++ b/lib/core/core.c
@@ -52,31 +52,31 @@ inline void __core_err_handler_inline(jes_err_t e, void* args){
     switch (e)
     {
     case e_err_mem_null:
-        description = "Memory could not be allocated!";
+        description = "Malloc fail!";
         break;
     case e_err_is_zero:
-        description = "Result is unexpectedly 0!";
+        description = "Unexpected 0!";
         break;
     case e_err_param:
-        description = "Parameter error!";
+        description = "Param error!";
         break;
     case e_err_peripheral_block:
-        description = "Peripheral was blocked!";
+        description = "Peripheral blocked!";
         break;
     case e_err_core_fail:
-        description = "Core failure!";
+        description = "Core fault!";
         break;
     case e_err_duplicate:
-        description = "Entry already exists!";
+        description = "Already exists!";
         break;
     case e_err_too_long:
-        description = "Given string is too long!";
+        description = "String too long!";
         break;
     case e_err_unknown_job:
-        description = "Job has not been registered!";
+        description = "Job not registered!";
         break;
     case e_err_leading_whitespace:
-        description = "Leading whitespace error!";
+        description = "Leading whitespace!";
         break;
     case e_err_prohibited:
         description = "Access denied!";
@@ -85,14 +85,14 @@ inline void __core_err_handler_inline(jes_err_t e, void* args){
         description = "Unknown error.";
         break;
     }
-    sprintf(err_print_job->args, "%s (%d)\n\r", description, e);
+    sprintf(err_print_job->args, "(E:) %s (%d)", description, e);
     __job_launch_job(err_print_job, e_origin_core);
 }
 
 
 void __core_job_err_handler(void* p){
     job_struct_t* pj = (job_struct_t*)p;
-    __core_err_handler_inline(pj->error, NULL);
+    __core_err_handler_inline((uint32_t)pj->param, NULL);
 }
 
 

--- a/lib/core/core.c
+++ b/lib/core/core.c
@@ -1,3 +1,4 @@
+#include <stdlib.h>
 #include "core.h"
 #include "cli.h"
 #include "base_jobs.h"
@@ -16,29 +17,42 @@ static core_t core = {
 };
 
 jes_err_t __core_init(){
-    if(core.state == e_state_idle) return e_err_no_err;
+    if(core.state != e_state_init) return e_err_no_err;
     jes_err_t e;
+    // Register the bare minimum of core and error handler
     e = __job_register_job(CORE_JOB_NAME, BOARD_MIN_JOB_HEAP_MEM, 1, __core_job, 1, e_role_core);
     if(e != e_err_no_err){ return e; }
     e = __job_register_job(ERROR_HANDLER_NAME, BOARD_MIN_JOB_HEAP_MEM, 1, __core_job_err_handler, 0, e_role_core);
     if(e != e_err_no_err){ return e; }
 
+    // Launch the core
+    e = __job_launch_job_by_name(CORE_JOB_NAME, e_origin_core);
+    if(e != e_err_no_err){ return e; }
+
+    // Launch the CLI if enabled
     #ifndef JES_DISABLE_CLI
+    // Initialize the underlying UART drivers and variables
+    e = __cli_init();
+    if(e != e_err_no_err){ return e; }
+
+    // register jobs associated with CLI
+    e = __job_register_job(CLI_SERVER_NAME, BOARD_MIN_JOB_HEAP_MEM, 1, cli_server, 1, e_role_core);
+    if(e != e_err_no_err){ return e; }
     #if __JES_LOG_LEN > 0
     e = __job_register_job(LOG_PRINTER_NAME, BOARD_MIN_JOB_HEAP_MEM, 1, __core_log_printer, 0, e_role_base);
     #endif // __JES_LOG_LEN > 0
-    e = __cli_init();
-    if(e != e_err_no_err){ return e; }
     e = __job_register_job(HELP_NAME, BOARD_MIN_JOB_HEAP_MEM, 1, __base_job_help, 0, e_role_base);
     if(e != e_err_no_err){ return e; }
     e = __job_register_job(STATS_NAME, BOARD_MIN_JOB_HEAP_MEM, 1, __base_job_stats, 0, e_role_base);
     if(e != e_err_no_err){ return e; }
     e = __job_register_job(BENCH_NAME, BOARD_MIN_JOB_HEAP_MEM, 1, __base_job_bench, 0, e_role_base);
     if(e != e_err_no_err){ return e; }
-    #endif
-    
-    e = __job_launch_job_by_name(CORE_JOB_NAME, e_origin_core);
+    e = __job_register_job(PRINT_JOB_NAME, BOARD_MIN_JOB_HEAP_MEM, 1, __base_job_echo, 0, e_role_base);
     if(e != e_err_no_err){ return e; }
+    // Launch CLI server
+    e = __job_launch_job_by_name(CLI_SERVER_NAME, e_origin_core);
+    if(e != e_err_no_err){ return e; }
+    #endif
 
     core.state = e_state_idle;
     return e_err_no_err;
@@ -46,8 +60,6 @@ jes_err_t __core_init(){
 
 
 inline void __core_err_handler_inline(jes_err_t e, void* args){
-
-    job_struct_t* err_print_job = __job_get_job_by_name(PRINT_JOB_NAME);
     const char* description = NULL;
     switch (e)
     {
@@ -85,14 +97,15 @@ inline void __core_err_handler_inline(jes_err_t e, void* args){
         description = "Unknown error.";
         break;
     }
-    sprintf(err_print_job->args, "(E:) %s (%d)", description, e);
-    __job_launch_job(err_print_job, e_origin_core);
+    uart_unif_writef("(E:) %s (%d)\n\r", description, e);
+    __cli_close_sess();
 }
 
 
 void __core_job_err_handler(void* p){
     job_struct_t* pj = (job_struct_t*)p;
-    __core_err_handler_inline((uint32_t)pj->param, NULL);
+    jes_err_t e = (jes_err_t)atoi(pj->args);
+    __core_err_handler_inline(e, NULL);
 }
 
 
@@ -202,6 +215,7 @@ void __core_log_printer(void* p){
 #endif // __JES_LOG_LEN > 0
 
 void __core_job(void* p){
+    job_struct_t* pself = (job_struct_t*)p;
     while(1){
         job_struct_t* pj = __job_sleep_until_notified_with_job();
         if(pj == NULL){
@@ -216,13 +230,16 @@ void __core_job(void* p){
         }
         else{
             core.state = e_state_spawning;
-            pj->error = __job_launch_job_by_name(pj->name, pj->caller);
+            if(pj->error == e_err_no_err){
+                pj->error = __job_launch_job(pj, pj->caller);
+            }
             if(pj->error != e_err_no_err){
                 core.state = e_state_fault;
                 __core_err_handler_inline(pj->error, NULL);
                 JES_LOG_FAULT(pj);
             }
         }
+        pself->error = e_err_no_err;
         core.state = e_state_idle;
     }
 }

--- a/lib/core/core.c
+++ b/lib/core/core.c
@@ -22,8 +22,6 @@ jes_err_t __core_init(){
     // Register the bare minimum of core and error handler
     e = __job_register_job(CORE_JOB_NAME, BOARD_MIN_JOB_HEAP_MEM, 1, __core_job, 1, e_role_core);
     if(e != e_err_no_err){ return e; }
-    e = __job_register_job(ERROR_HANDLER_NAME, BOARD_MIN_JOB_HEAP_MEM, 1, __core_job_err_handler, 0, e_role_core);
-    if(e != e_err_no_err){ return e; }
 
     // Launch the core
     e = __job_launch_job_by_name(CORE_JOB_NAME, e_origin_core);
@@ -58,8 +56,10 @@ jes_err_t __core_init(){
     return e_err_no_err;
 }
 
-
-inline void __core_err_handler_inline(jes_err_t e, void* args){
+/// @brief Core error handler.
+/// @param e: Error to handle.
+/// @param args: optional additional arguments.
+static inline void __core_err_handler_inline(jes_err_t e, void* args){
     const char* description = NULL;
     switch (e)
     {

--- a/lib/core/core.h
+++ b/lib/core/core.h
@@ -71,12 +71,6 @@ typedef struct core_t{
 jes_err_t __core_init();
 
 
-/// @brief Core error handler.
-/// @param e: Error to handle.
-/// @param args: optional additional arguments.
-void __core_err_handler_inline(jes_err_t e, void* args);
-
-
 /// @brief Error handler as callable job
 /// @param p: Mandatory args pointer.
 void __core_job_err_handler(void* p);

--- a/lib/core/core.h
+++ b/lib/core/core.h
@@ -28,6 +28,7 @@ extern "C" {
 #define JES_LOG_FAULT(pj) 
 #define JES_LOG_REGISTER(pj) 
 #define JES_LOG_LAUNCH(pj) 
+#define JES_LOG_FINISH(pj)
 #endif // __JES_LOG_LEN > 0
 
 

--- a/lib/job_names/core_job_names.h
+++ b/lib/job_names/core_job_names.h
@@ -6,7 +6,7 @@ extern "C" {
 #define _CORE_JOB_NAMES_H_
 
 #define CORE_JOB_NAME       "core"
-#define ERROR_HANDLER_NAME  "errorhandler"
+#define ERROR_HANDLER_NAME  "errh"
 #ifndef JES_DISABLE_CLI
 #define CLI_SERVER_NAME    "clisrv"
 #if __JES_LOG_LEN > 0

--- a/lib/job_names/core_job_names.h
+++ b/lib/job_names/core_job_names.h
@@ -6,7 +6,6 @@ extern "C" {
 #define _CORE_JOB_NAMES_H_
 
 #define CORE_JOB_NAME       "core"
-#define ERROR_HANDLER_NAME  "errh"
 #ifndef JES_DISABLE_CLI
 #define CLI_SERVER_NAME    "clisrv"
 #if __JES_LOG_LEN > 0

--- a/lib/unified/uart_unif.h
+++ b/lib/unified/uart_unif.h
@@ -16,11 +16,7 @@ extern "C" {
 #include "queue.h"
 #endif
 
-#ifdef UNIF_UART_WRITE_BUF_SIZE
-#define __UNIF_UART_WRITE_BUF_SIZE UNIF_UART_WRITE_BUF_SIZE
-#else
-#define __UNIF_UART_WRITE_BUF_SIZE __MAX_JOB_ARGS_LEN_BYTE
-#endif
+#define __UNIF_UART_WRITE_BUF_SIZE (__MAX_JOB_NAME_LEN_BYTE + __MAX_JOB_ARGS_LEN_BYTE)
 
 #define __extraUART_CLOSE_SESS      6
 #define __extraUART_INVALID         7

--- a/lib/unified/uart_unif.h
+++ b/lib/unified/uart_unif.h
@@ -22,6 +22,8 @@ extern "C" {
 #define __UNIF_UART_WRITE_BUF_SIZE __MAX_JOB_ARGS_LEN_BYTE
 #endif
 
+#define __extraUART_CLOSE_SESS      6
+#define __extraUART_INVALID         7
 #ifdef BUILD_FOR_STM32
 #define UART_DATA           0
 #define UART_FIFO_OVF       1

--- a/library.json
+++ b/library.json
@@ -1,6 +1,6 @@
 {
     "name": "jescore",
-    "version": "2.2.0",
+    "version": "2.2.1",
     "description": "FreeRTOS attached core for easier multitasking and native CLI support",
     "keywords": "core, FreeRTOS",
     "repository":

--- a/platformio.ini
+++ b/platformio.ini
@@ -130,6 +130,27 @@ build_type = test
 build_src_filter = -<src/> +<test/>
 test_build_src = yes
 
+[env:esp32-heltec-v3-release-arduino]
+extends = _env:esp32-arduino
+board = heltec_wifi_lora_32_V3
+build_type = release
+
+[env:esp32-heltec-v3-debug-arduino]
+extends = _env:esp32-arduino
+board = heltec_wifi_lora_32_V3
+build_type = debug
+debug_speed = 40000
+debug_init_break = tbreak setup
+debug_tool = esp-builtin
+debug_build_flags = -O0 -g -ggdb
+
+[env:esp32-heltec-v3-test-arduino]
+extends = _env:esp32-arduino
+board = heltec_wifi_lora_32_V3
+build_type = test
+build_src_filter = -<src/> +<test/>
+test_build_src = yes
+
 [env:stm32_l476rg-release-cube]
 extends = _env:stm32-cube
 board = nucleo_l476rg

--- a/scripts/jescore_linking.py
+++ b/scripts/jescore_linking.py
@@ -169,7 +169,6 @@ def get_fw_version():
 
     for file in version_files:
         file = join(jescore_as_lib, file)
-        print("DEBUGG: ", file)
         if exists(file):
             
             try:

--- a/scripts/jescore_linking.py
+++ b/scripts/jescore_linking.py
@@ -54,6 +54,8 @@ jescore_as_lib = os.path.join(env["PROJECT_LIBDEPS_DIR"], env["PIOENV"], "jescor
 print(f"Starting dynamic linking script for jescore on {Color.G + mcu + Color.X} ...")
 # ESP32 specific linking is done out-of-the-box
 if "esp" in mcu:
+    if not os.path.exists(jescore_as_lib):
+        jescore_as_lib = "."
     print(" > Found ESP32 platform, defaulting to base config ...")
 
 else:
@@ -157,25 +159,6 @@ else:
     print(f"FreeRTOS Path: {Color.G + freertos_port_path + Color.X}")
 
 
-def get_git_info():
-    try:
-        branch = subprocess.check_output(
-            ["git", "-C", jescore_as_lib, "rev-parse", "--abbrev-ref", "HEAD"],
-            stderr=subprocess.STDOUT
-        ).decode("utf-8").strip()
-    except:
-        branch = "unknown"
-
-    try:
-        githash = subprocess.check_output(
-            ["git", "-C", jescore_as_lib, "rev-parse", "--short", "HEAD"],
-            stderr=subprocess.STDOUT
-        ).decode("utf-8").strip()
-    except:
-        githash = "unknown"
-
-    return branch, githash
-
 def get_fw_version():
     version = "unknown"
     version_files = [
@@ -186,7 +169,9 @@ def get_fw_version():
 
     for file in version_files:
         file = join(jescore_as_lib, file)
+        print("DEBUGG: ", file)
         if exists(file):
+            
             try:
                 with open(file) as f:
                     if file.endswith('.json'):
@@ -196,7 +181,8 @@ def get_fw_version():
                         version = f.read().strip()
                 break
             except:
-                pass
+                print("sus")
+                # pass
 
     return version
 

--- a/test/common_test.c
+++ b/test/common_test.c
@@ -37,7 +37,6 @@ void test_all(void* p) {
     RUN_TEST(test_core_init);
     jes_delay_job_ms(100);
     RUN_TEST(test_job_core);
-    RUN_TEST(test_job_error_handler);
     RUN_TEST(test_cli_init);
     RUN_TEST(test_job_help);
     RUN_TEST(test_job_stats);

--- a/test/common_test.h
+++ b/test/common_test.h
@@ -16,7 +16,6 @@ extern "C" {
 
 void test_core_init(void);
 void test_job_core(void);
-void test_job_error_handler(void);
 void test_cli_init(void);
 void test_job_help(void);
 void test_job_stats(void);

--- a/test/test_api_functions.c
+++ b/test/test_api_functions.c
@@ -267,6 +267,6 @@ void test_notify_job_and_wait(void){
 
     uint32_t* val = (uint32_t*)__job_get_param(__job_get_job_by_name(DUMMY_JOB_NOTIFY_TAKE));
     char* msg = __job_get_args(__job_get_job_by_name(DUMMY_JOB_NOTIFY_TAKE));
-    TEST_ASSERT_EQUAL_UINT8(DUMMY_NOTIFICATION_VALUE, (uint32_t)val);
+    TEST_ASSERT_EQUAL_UINT32(DUMMY_NOTIFICATION_VALUE, (uint32_t)val);
     TEST_ASSERT_EQUAL_STRING(DUMMY_SUCCESS_MSG, msg);
 }

--- a/test/test_api_functions.c
+++ b/test/test_api_functions.c
@@ -245,10 +245,6 @@ void test_core_job_launch_prohibited(void){
     log_entry_t le = __core_read_from_log_next();
     TEST_ASSERT_EQUAL(e_err_prohibited, le.job_state.error);
     #endif // __JES_LOG_LEN > 0
-    stat = jes_launch_job(ERROR_HANDLER_NAME);
-    TEST_ASSERT_EQUAL_INT(e_err_no_err, stat);
-    jes_delay_job_ms(20);
-    TEST_ASSERT_EQUAL(e_err_prohibited, jes_error_get(ERROR_HANDLER_NAME));
     stat = jes_launch_job(CLI_SERVER_NAME);
     TEST_ASSERT_EQUAL_INT(e_err_no_err, stat);
     jes_delay_job_ms(20);

--- a/test/test_api_functions.c
+++ b/test/test_api_functions.c
@@ -234,10 +234,17 @@ void test_error_throw_get(void){
 
 
 void test_core_job_launch_prohibited(void){
-    jes_err_t stat = jes_launch_job(CORE_JOB_NAME);
+    jes_err_t stat;
+    #if __JES_LOG_LEN > 0
+    /*  The core refreshes its error state to `e_err_no_err`
+        after every iteration. However, the error is logged.
+    */
+    stat = jes_launch_job(CORE_JOB_NAME);
     TEST_ASSERT_EQUAL_INT(e_err_no_err, stat);
     jes_delay_job_ms(20);
-    TEST_ASSERT_EQUAL(e_err_prohibited, jes_error_get(CORE_JOB_NAME));
+    log_entry_t le = __core_read_from_log_next();
+    TEST_ASSERT_EQUAL(e_err_prohibited, le.job_state.error);
+    #endif // __JES_LOG_LEN > 0
     stat = jes_launch_job(ERROR_HANDLER_NAME);
     TEST_ASSERT_EQUAL_INT(e_err_no_err, stat);
     jes_delay_job_ms(20);

--- a/test/test_core_startup.c
+++ b/test/test_core_startup.c
@@ -55,24 +55,6 @@ void test_job_core(void){
 }
 
 
-void test_job_error_handler(void){
-    char dummy[__MAX_JOB_ARGS_LEN_BYTE] = {0};
-    job_struct_t* pj = __job_get_job_by_name(ERROR_HANDLER_NAME);
-    TEST_ASSERT_EQUAL_STRING(ERROR_HANDLER_NAME, pj->name);
-    TEST_ASSERT_EQUAL_HEX32(NULL, pj->handle);
-    TEST_ASSERT_EQUAL_UINT32(BOARD_MIN_JOB_HEAP_MEM, pj->mem_size);
-    TEST_ASSERT_EQUAL_UINT8(1, pj->priority);
-    TEST_ASSERT_EQUAL_HEX32(__core_job_err_handler, pj->function);    
-    TEST_ASSERT_EQUAL_INT8_ARRAY(dummy, pj->args, __MAX_JOB_ARGS_LEN_BYTE);
-    TEST_ASSERT_EQUAL_UINT8(0, pj->is_loop);
-    TEST_ASSERT_EQUAL_UINT8(0, pj->instances);
-    TEST_ASSERT_EQUAL_INT(e_role_core, pj->role);
-    TEST_ASSERT_EQUAL_INT(e_origin_undefined, pj->caller);
-    TEST_ASSERT_EQUAL_HEX32(NULL, pj->param);
-    TEST_ASSERT_EQUAL_INT(e_err_no_err, pj->error);
-}
-
-
 void test_cli_init(void){
     jes_err_t e = __cli_init();
     TEST_ASSERT_EQUAL(e_err_no_err, e);


### PR DESCRIPTION
## 2.2.1 - 2025-09-29

### Added
- 💬 UART queue commands for invalid data and CLI session closing
- 🌊 Early termination on CLI input overflow 
- 🔆 Core now checks for errors in job **before** launch as well
- 🛡️ Macros for generic resource protection
- ‼️ UART double buffer to stop DMA override of burst data

### Changed
- 🚫 Shorter error messages
- 🧑‍🌾 Reduced heap size for STM32 projects

### Fixed
- 🔆 Core initializer now calls all registrations in one place 
- `jescore dynamic linker` adds the FW version to ESP32 builds again

### Removed
- 🛠️ Public reference to CLI helper functions
- ❌ `errorhandler` is now inline and no longer a job
- 😺 `jescore dynamic linker` will no longer log git information